### PR TITLE
Add dedicated 404 page

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>JenshinSolver</title>
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://mgatelabs.github.io/GenshinSolvers/"
+    />
+  </head>
+  <body>
+    <p>
+      If you are not redirected in five seconds,
+      <a href="https://mgatelabs.github.io/GenshinSolvers/">click here</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
This adds a 404 page which should automatically redirect the user.

With this, we can get rid of the `@powershell copy \"./dist/index.html\" \"./dist/404.html\"` command.