### PR TITLE
Use actual buttons for the arrows

### DIFF
--- a/src/app/puzzle-configuration/puzzle-configuration.component.html
+++ b/src/app/puzzle-configuration/puzzle-configuration.component.html
@@ -4,18 +4,15 @@
     *ngFor="let dir of puzzleConfiguration.directions; let i = index"
   >
     #{{ i + 1 }} -
-    <fa-icon
-      class="icon-click-left"
-      (click)="arrowClicked(i, true)"
-      [icon]="['fas', 'angle-left']"
-    ></fa-icon>
+    <button class="icon-click-left" (click)="arrowClicked(i, true)">
+      <fa-icon [icon]="['fas', 'angle-left']"></fa-icon>
+    </button>
+
     <span class="icon-value" (click)="arrowClicked(i, false)">
       {{ getDirectionValue(dir) }}
     </span>
-    <fa-icon
-      class="icon-click-right"
-      (click)="arrowClicked(i, false)"
-      [icon]="['fas', 'angle-right']"
-    ></fa-icon>
+    <button class="icon-click-right" (click)="arrowClicked(i, false)">
+      <fa-icon [icon]="['fas', 'angle-right']"></fa-icon>
+    </button>
   </div>
 </div>

--- a/src/app/puzzle-configuration/puzzle-configuration.component.scss
+++ b/src/app/puzzle-configuration/puzzle-configuration.component.scss
@@ -12,6 +12,13 @@
 .icon-click-right,
 .icon-value {
   cursor: pointer;
+  border: 0px;
+  background: transparent;
+}
+
+.icon-click-left:hover,
+.icon-click-right:hover {
+  outline: 1px solid black;
 }
 
 .icon-value {


### PR DESCRIPTION
Solves the odd "selecting" that happens when double-clicking the arrows.
It's also a bit better this way from an accessibility standpoint.